### PR TITLE
QTA-98: Added support for making requests through a proxy and allow TLS cert failures to be raised.

### DIFF
--- a/python/platina_sdk/pcc_easy_api.py
+++ b/python/platina_sdk/pcc_easy_api.py
@@ -5,12 +5,14 @@ DEFAULT_PCC_LOGIN_PASSWORD = "admin"
 ## Login
 def login(url:str, 
           username:str=DEFAULT_PCC_LOGIN_USERNAME,
-          password:str=DEFAULT_PCC_LOGIN_PASSWORD)->dict:
-    return pcc.login(url, username, password)
+          password:str=DEFAULT_PCC_LOGIN_PASSWORD,
+          proxy:str=None,
+          insecure:bool=False)->dict:
+    return pcc.login(url, username, password, proxy, insecure)
 
 
 def add_node_group(**kwargs)->dict:
-    if "Desctiption" not in kwargs:
+    if "Description" not in kwargs:
         kwargs["Description"] = None
     try:
         data = {

--- a/python/platina_sdk/utils.py
+++ b/python/platina_sdk/utils.py
@@ -6,50 +6,54 @@ import time
 
 def get(conn, url_path):
     # DISABLE SSL error
-    urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+    if "options" in conn and "insecure" in conn["options"] and conn["options"]["insecure"]:
+        urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
     headers = {
         'Content Type': 'application/json',
         'Authorization': 'Bearer %s' % conn['token']
     }
     url = conn['url'] + url_path
-    response = conn['session'].get(url, headers=headers)
+    response = conn['session'].get(url, headers=headers, proxies=conn['proxies'])
     return _serialize_response(time.time(), response)
 
 def delete(conn, url_path, data=None):
     # DISABLE SSL error
-    urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+    if "options" in conn and "insecure" in conn["options"] and conn["options"]["insecure"]:
+        urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
     headers = {
         'Content Type': 'application/json',
         'Authorization': 'Bearer %s' % conn['token']
     }
     url = conn['url'] + url_path
-    response = conn['session'].delete(url, headers=headers)
+    response = conn['session'].delete(url, headers=headers, proxies=conn['proxies'])
     return _serialize_response(time.time(), response)
 
 def post(conn, url_path, payload):
     # DISABLE SSL error
-    urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+    if "options" in conn and "insecure" in conn["options"] and conn["options"]["insecure"]:
+        urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
     headers = {
         'Content Type': 'application/json',
         'Authorization': 'Bearer %s' % conn['token']
     }
     url = conn['url'] + url_path
-    response = conn['session'].post(url, json=payload, headers=headers)
+    response = conn['session'].post(url, json=payload, headers=headers, proxies=conn['proxies'])
     return _serialize_response(time.time(), response)
 
 def put(conn, url_path, payload):
     # DISABLE SSL error
-    urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+    if "options" in conn and "insecure" in conn["options"] and conn["options"]["insecure"]:
+        urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
     headers = {
         'Content Type': 'application/json',
         'Authorization': 'Bearer %s' % conn['token']
     }
     url = conn['url'] + url_path
-    response = conn['session'].put(url, json=payload, headers=headers)
+    response = conn['session'].put(url, json=payload, headers=headers, proxies=conn['proxies'])
     return _serialize_response(time.time(), response)
 
 def _serialize_response(start_time, response):


### PR DESCRIPTION
I've tested this with some code to call add_node_group() through easy_pcc.py. The current calling conventions (without specifying a proxy or the insecure option) work and I'm also able to run the test code on my laptop at home against a PCC instance in the lab.

For the latter, I installed the Debian python-socks package (a dependency that python-requests has in order to provide support for SOCKS5 proxies) and then started an ssh session thusly:

`ssh -A -D3128 -J 50.208.49.153:3028 172.17.2.28`

(the -A option isn't necessary for this test, but was for other stuff I'm doing).

Then I was able to call the login() function in pcc_easy.py thusly:
`conn = pcc.login('https://172.17.2.211:9999','admin','admin','socks5://localhost:3128', True)`

This worked, whereas it didn't without the proxy. The subsequent call to add_node_group() also worked using the proxy info inside the conn dictionary.

On a machine that trusts the Platina Root CA, I get no TLS errors calling like this:
`conn = pcc.login('https://pcc-211.lab.platinasystems.com:9999','admin','admin','socks5://localhost:3128', False)`

But do if I use the IP address instead of the name.

This shouldn't require any changes to any current callers (ie, the test suite) unless you want to pass `insecure=True` into the login() calls.